### PR TITLE
Fix incorrect `Py_XDECREF/Py_DECREF` call on stolen reference after `PyList_SetItem` failure

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -72,7 +72,6 @@ copy_grouping(char* s)
         if (!val)
             break;
         if (PyList_SetItem(result, i, val)) {
-            Py_DECREF(val);
             val = NULL;
             break;
         }

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -606,7 +606,6 @@ poll_poll(pollObject *self, PyObject *args)
             }
             PyTuple_SET_ITEM(value, 1, num);
             if ((PyList_SetItem(result_list, j, value)) == -1) {
-                Py_DECREF(value);
                 goto error;
             }
             i++;
@@ -903,7 +902,6 @@ devpoll_poll(devpollObject *self, PyObject *args)
             if (value == NULL)
                 goto error;
             if ((PyList_SetItem(result_list, i, value)) == -1) {
-                Py_DECREF(value);
                 goto error;
             }
         }


### PR DESCRIPTION
Close #10 